### PR TITLE
Fix behavior of -o parameter

### DIFF
--- a/PKGTool/Program.cs
+++ b/PKGTool/Program.cs
@@ -124,7 +124,7 @@ namespace PKGTool
                         if (args.Length == 4)
                         {
                             if (args[2] == "-o")
-                                outPath = args[2];
+                                outPath = args[3];
                             else
                             {
                                 Usage();


### PR DESCRIPTION
Currently, specifying any output folder will always set the output to a folder named "-o".