### PR TITLE
Fix compiling on Linux

### DIFF
--- a/PKGTool/Properties/Resources.resx
+++ b/PKGTool/Properties/Resources.resx
@@ -119,6 +119,6 @@
   </resheader>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="resource_infos" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\dread\resources\resource_infos.json;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>..\Dread\Resources\resource_infos.json;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
 </root>


### PR DESCRIPTION
Since most *NIX filesystems are case sensitive building currently breaks, this fixes it.